### PR TITLE
better support for array checking and array length checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ validate.re = {
 validate.Validator = Validator;
 
 function Validator (schema, values) {
-  this.values = values;
+  this._values = values;
   this.accepted = {};
   this.schema = schema;
   this.errors = [];
@@ -20,7 +20,7 @@ function Validator (schema, values) {
 
 Validator.prototype.walk = function (schemas, values, accepted) {
   schemas = schemas || this.schema;
-  values = values || this.values;
+  values = values || this._values;
   accepted = accepted || this.accepted;
   
   Object.keys(schemas).forEach(function (key) {
@@ -41,27 +41,10 @@ Validator.prototype.walk = function (schemas, values, accepted) {
       return;
     }
 
-    if (schema.arrayMinLen || schema.arrayMaxLen 
-      || schema.arrayLen || schema.array
-    ) {
-      var arraySchema = {
-          arrayMinLen: schema.arrayMinLen
-        , arrayMaxLen: schema.arrayMaxLen
-        , arrayLen: schema.arrayLen
-        , array: schema.array
-      };
-
-      schema = Object.create(schema);
-      schema.arrayMinLen = null;
-      schema.arrayMaxLen = null;
-      schema.arrayLen = null;
-      schema.array = null;
-
-      allValid = this.validate(arraySchema, value) && allValid;
-    }
+    allValid = this.validate(schema, value) && allValid;
 
     for (var i = 0; i < value.length; i++)
-      allValid = this.validate(schema, value[i]) && allValid;
+      allValid = this.validate(schema.values, value[i]) && allValid;
 
     if (allValid) accepted[key] = value;
   }, this);
@@ -120,6 +103,8 @@ Validator.prototype.type = function (type, value) {
       return validate.re.hex.test(value);
     case 'date':
       return value instanceof Date;
+    case 'array':
+      return Array.isArray(value);
     default:
       return typeof value === type;
   }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,10 @@ var schema = {
     , city      : { type: 'string', required: true }
     , zip       : { type: 'string', length: 8, message: "Invalid zip" }
   }
-  , array   : { type: 'number', array: true, arrayMinLen: 1 }
+  , array   : { type: 'array', minLen: 1, values: {
+                type: 'number'
+            } 
+  }
 };
 
 var data = validate(schema, { /* data to validate */ });

--- a/test.js
+++ b/test.js
@@ -79,7 +79,14 @@ var tests = module.exports = {
   },
   
   'test array': function () {
-    var schema = { test: { type: 'number' } };
+    var schema = { 
+      test: { 
+        values: {
+          type: 'number'
+        },
+        type: 'array'
+      } 
+    };
     
     assert.deepEqual(validate(schema, { test: [3, 2, 1] }), {
       test: [3,2,1]
@@ -103,7 +110,10 @@ var tests = module.exports = {
         , city      : { type: 'string', required: true }
         , zip       : { type: 'string', length: 8, message: "Invalid zip" }
       }
-      , array   : { type: 'number', arrayMinLen: 2, array: true }
+      , array   : { type: 'array', minLen: 2, values: {
+                    type: 'number'
+                }
+      }
     };
 
     assert.deepEqual(validate(schema, {
@@ -131,9 +141,18 @@ var tests = module.exports = {
 
   'test arrays': function () {
     var schema = {
-        name: { type: 'string', arrayLen: 2, array: true }
-      , foos: { type: 'string', arrayMinLen: 1, array: true }
-      , bars: { type: 'string', arrayMaxLen: 3, array: true }
+        name: { type: 'array', len: 2, values: {
+                type: 'string'
+            }
+      }
+      , foos: { type: 'array', minLen: 1, values: {
+                type: 'string'
+            }
+      }
+      , bars: { type: 'array', maxLen: 3, values: {
+                type: 'string'
+            }
+      }
     };
 
     assert.deepEqual(validate(schema, {


### PR DESCRIPTION
This is iffy.

It works but there may be a more elegant way.
## Motivation
### For the array property

```
var schema = {
    foo: {
        array: true,
        type: "string"
    }
}
```

`validate(schema, { foo: "bar" })` fails

`validate(schema, { foo: ["bar"] })` succeeds
### For the array length properties

```
var schema = {
    foos: {
        type: "string",
        array: true,
        arrayMinLen: 1
    }
}
```

`validate(schema, { foos: [] })` fails

`validate(schema, { foos: ["foo"] })` succeeds 
