### PR TITLE
Fix `required: false` behavior and add tests

### DIFF
--- a/lib/property.js
+++ b/lib/property.js
@@ -55,8 +55,18 @@ Property.prototype = {
    */
   
   required: function (bool, msg) {
-    if ('string' == typeof bool) msg = bool;
-    return this.use(required(), msg);
+    if ('string' === typeof bool) {
+      msg = bool;
+      bool = true;
+    } else if (bool == null) {
+      bool = true;
+    }
+
+    if(bool === true) {
+      return this.use(required(), msg);
+    }
+
+    return this;
   },
   
   /**

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "valid",
     "object"
   ],
-  "scirpts": {
+  "scripts": {
     "test": "make test"
   },
   "dependencies": {

--- a/test/schema.js
+++ b/test/schema.js
@@ -28,6 +28,12 @@ describe('Schema', function () {
         schema.path('name', { first: { required: true }});
         schema.validate({}).should.have.length(1);
       })
+
+      it('should respect `required: false`', function () {
+        var schema = new Schema();
+        schema.path('name', { first: { required: false }});
+        schema.validate({}).should.have.length(0);
+      })
       
       it('should return a Property', function () {
         var schema = new Schema();


### PR DESCRIPTION
When a property has `required: false`, it should not be required. Tests
pass, but this is possibly a breaking change as there's quite a bit of
undefined behavior on http://git.io/vnVBu. People from #23 are using
`required: false` and may have this problem.