### PR TITLE
Fix typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ const post = new Schema({
   title: { required: true }
 })
 
-post.messsage({
+post.message({
   required: (path) => `${path} can not be empty.`
 })
 


### PR DESCRIPTION
Remove extra 's' in 'post.message'