### PR TITLE
Add size validator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -432,6 +432,26 @@ prop.length(10)
 
 Returns **[Property](#property)**
 
+#### size
+
+Registers a validator that checks size.
+
+**Parameters**
+
+-   `size` **([Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))** object with `.min` and `.max` properties or a number
+    -   `size.min` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** minimum length
+    -   `size.max` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** maximum length
+
+**Examples**
+
+```javascript
+prop.size({ min: 8, max: 255 })
+prop.size(10)
+```
+
+Returns **[Property](#property)**
+
+
 #### enum
 
 Registers a validator for enums.

--- a/src/messages.js
+++ b/src/messages.js
@@ -43,6 +43,25 @@ const Messages = {
     }
   },
 
+  // Size message
+  size(prop, ctx, size) {
+    if (typeof size == 'number') {
+      return `${prop} must have a size of ${size}.`;
+    }
+
+    const {min, max} = size;
+
+    if (min && max) {
+      return `${prop} must be between ${min} and ${max}.`;
+    }
+    if (max) {
+      return `${prop} must be less than ${max}.`;
+    }
+    if (min) {
+      return `${prop} must be greater than ${min}.`;
+    }
+  },
+
   // Enum message
   enum(prop, ctx, enums) {
     const copy = enums.slice();

--- a/src/validators.js
+++ b/src/validators.js
@@ -60,6 +60,27 @@ const Validators = {
   },
 
   /**
+   * Validates size.
+   *
+   * @param {Number} value the number being validated
+   * @param {Object} ctx the object being validated
+   * @param {Object|Number} size object with .min and/or .max props or a number
+   * @param {String|Number} [size.min] - minimum size
+   * @param {String|Number} [size.max] - maximum size
+   * @return {Boolean}
+   */
+
+  size(value, ctx, size) {
+    if (typeof size == 'number') {
+      return value === size;
+    }
+    let {min, max} = size;
+    if (parseInt(min) !== undefined && value < min) return false;
+    if (parseInt(max) !== undefined && value > max) return false;
+    return true;
+  },
+
+  /**
    * Validates enums.
    *
    * @param {String} value the string being validated

--- a/test/validators.js
+++ b/test/validators.js
@@ -80,6 +80,31 @@ describe('Validators', () => {
     });
   });
 
+  describe('.size()', () => {
+    test(
+      'should return true if given value has size between given min and max',
+      () => {
+        expect(Validators.size(2, {}, { min: 2, max: 4 })).toBe(true);
+        expect(Validators.size(3, {}, { min: 2, max: 4 })).toBe(true);
+        expect(Validators.size(4, {}, { min: 2, max: 4 })).toBe(true);
+        expect(Validators.size(5, {}, { min: 2 })).toBe(true);
+        expect(Validators.size(1, {}, { max: 4 })).toBe(true);
+      }
+    );
+
+    test('should return false otherwise', () => {
+      expect(Validators.size(1, {}, { min: 2, max: 4 })).toBe(false);
+      expect(Validators.size(5, {}, { min: 2, max: 4 })).toBe(false);
+      expect(Validators.size(1, {}, { min: 2 })).toBe(false);
+      expect(Validators.size(5, {}, { max: 4 })).toBe(false);
+    });
+
+    test('should work with a number as an exact size', () => {
+      expect(Validators.size(1, {}, 2)).toBe(false);
+      expect(Validators.size(2, {}, 2)).toBe(true);
+    });
+  });
+
   describe('.enum()', () => {
     test('should return true if given value is included in given array', () => {
       expect(Validators.enum('a', {}, ['a', 'b'])).toBe(true);


### PR DESCRIPTION
Fixes #63

I added a `parseInt` check, so that `0` can be used as a valid value (as with `length` it'll not run the check, since `0` is falsey, which makes sense for strings, but not for numbers).