### PR TITLE
Shown message for min/max sizes === 0

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -51,13 +51,13 @@ const Messages = {
 
     const {min, max} = size;
 
-    if (min && max) {
+    if (min !== undefined && max !== undefined) {
       return `${prop} must be between ${min} and ${max}.`;
     }
-    if (max) {
+    if (max !== undefined) {
       return `${prop} must be less than ${max}.`;
     }
-    if (min) {
+    if (min !== undefined) {
       return `${prop} must be greater than ${min}.`;
     }
   },


### PR DESCRIPTION
After the addition of size validation (thanks @G-Rath ), I realised that when the min/max sizes were 0 the error message wasn't displayed.