### PR TITLE
Include typings in packaged module

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "testEnvironment": "node"
   },
   "files": [
-    "build"
+    "build",
+    "index.d.ts"
   ],
   "main": "build/schema.js",
   "license": "MIT"


### PR DESCRIPTION
Currently typescript types are not packaged, this pull request should fix that.