### PR TITLE
Fix importing problem

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
   "presets": ["@babel/preset-env"],
-  "plugins": ["add-module-exports"]
+  "plugins": [
+    [
+      "add-module-exports",
+      {
+        "addDefaultProperty": true
+      }
+    ]
+   ]
 }


### PR DESCRIPTION
See #101 for the error and a description of why it occurs. Basicly TS expects the module to have a `default` export when compiling down from ES6 to CommonJS. `add-module-exports` does not set it by default, causing the error. This patch will just add the needed export.

@eivindfjeldstad