### PR TITLE
Single enum variable validation message

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -66,7 +66,10 @@ const Messages = {
   enum(prop, ctx, enums) {
     const copy = enums.slice();
     const last = copy.pop();
-    return `${prop} must be either ${copy.join(', ')} or ${last}.`;
+
+    return copy.length
+      ? `${prop} must be either ${copy.join(', ')} or ${last}.`
+      : `${prop} must be ${last}.`
   },
 
   // Illegal property

--- a/test/messages.js
+++ b/test/messages.js
@@ -34,6 +34,9 @@ describe('Messages', () => {
     test('should return the correct message', () => {
       expect(Messages.enum('a', {}, ['b', 'c'])).toBe('a must be either b or c.');
     });
+    test('should return the correct message with single enum', () => {
+      expect(Messages.enum('a', {}, ['c'])).toBe('a must be c.');
+    });
   });
 
   describe('.illegal()', () => {


### PR DESCRIPTION
`    fieldName: {
        type: String,
        enum: ['A']
    },
`
return message 'fieldName must be either  or A.'