### PR TITLE
Property.enum(Number[] | String[])

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare class Property {
   date(): Property;
   length(rule: number | { min?: number; max?: number }): Property;
   size(rule: number | { min?: number; max?: number }): Property;
-  enum(enums: string[]): Property;
+  enum(enums: string[] | number[]): Property;
   match(regexp: RegExp): Property;
   each(rules: Rule): Property;
   elements(arr: Rule[]): Property;


### PR DESCRIPTION
Allow to pass number[] to enum. So property.number().enum([0, 1]) can be used in typescript without lint error.